### PR TITLE
v3 engine updates

### DIFF
--- a/AWSSecurityAnalyticsBootstrap/cfn/Athena_infra_setup.yml
+++ b/AWSSecurityAnalyticsBootstrap/cfn/Athena_infra_setup.yml
@@ -180,7 +180,7 @@ Resources:
         # This affects you only if you run queries in this workgroup. If you do, workgroup settings are used
         EnforceWorkGroupConfiguration: TRUE
         EngineVersion: 
-            SelectedEngineVersion: 'Athena engine version 2'
+            SelectedEngineVersion: 'Athena engine version 3'
         PublishCloudWatchMetricsEnabled: FALSE
         RequesterPaysEnabled: FALSE 
         ResultConfiguration: 

--- a/AWSSecurityAnalyticsBootstrap/sql/dml/analytics/vpcflow/vpcflow_demo_queries.sql
+++ b/AWSSecurityAnalyticsBootstrap/sql/dml/analytics/vpcflow/vpcflow_demo_queries.sql
@@ -250,8 +250,10 @@ AND region_partition in ('us-east-1','us-east-2','us-west-2', 'us-west-2')
 -- e.g. only return VPC Flow records between internal and external IP addresses
 SELECT * FROM vpcflow
 WHERE logstatus = 'OK' -- required to filter out '-' in the src/dst IP fields
-AND NOT (contains('172.16.0.0/12', cast(sourceaddress as IPADDRESS)) 
-AND contains('172.16.0.0/12', cast(destinationaddress as IPADDRESS)))
+AND NOT (
+    contains('172.16.0.0/12', cast(sourceaddress as IPADDRESS)) 
+    AND contains('172.16.0.0/12', cast(destinationaddress as IPADDRESS))
+)
 AND date_partition >= '2020/07/01'
 AND date_partition <= '2020/07/31'
 AND account_partition = '111122223333'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog - AWS Security Analytics Bootstrap
 
+## [1.1.0] - 2022-10-17
+- Updated to use Amazon Athena engine to v3 (latest) [link](https://docs.aws.amazon.com/athena/latest/ug/engine-versions-reference-0003.html)
+- Added new demo VPC Flow log queries for Athena engine v3
+
 ## [1.0.0] - 2021-07-02
 Initial Release under Apache License Version 2.0
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ By installing AWS Security Analytics Bootstrap, AWS customers may incur charges 
 AWS Security Analytics Bootstrap stands on the shoulders of countless giants and has benefited from the assistance of *MANY* collaborators and contributors.  Thanks to everyone who has helped or inspired the project so far and thanks in advance to any future contributions.
 
 Many thanks for your contributions:
+- Aaron Lennon
 - Bohan Li
 - Brian Andrzejewski
 - Brian Poole


### PR DESCRIPTION
- Updated to use Amazon Athena engine to v3 (latest) [link](https://docs.aws.amazon.com/athena/latest/ug/engine-versions-reference-0003.html)
- Added new demo VPC Flow log queries for Athena engine v3
